### PR TITLE
Update Signin Sheets To Support Pagingation

### DIFF
--- a/src/client/src/app/models/dto/SignInSheetDto.ts
+++ b/src/client/src/app/models/dto/SignInSheetDto.ts
@@ -3,5 +3,5 @@ import { EventDto, MemberAttendanceDto, RegistrationDto } from '.';
     export interface SignInSheetDto {
         event: EventDto;
         registration: RegistrationDto;
-        memberAttendance: MemberAttendanceDto[];
+        memberAttendances: MemberAttendanceDto[];
     }

--- a/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.css
+++ b/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.css
@@ -38,6 +38,8 @@
   left: 0;
   max-width: 140px;
   max-height: 100px;
+  display: block;
+  z-index: 20;
 }
 
 .container {
@@ -54,6 +56,8 @@
 table {
   border: solid 1px #000;
   width: 100%;
+  position: relative;
+  z-index: 1;
 }
 
 td {
@@ -96,4 +100,36 @@ td {
   .infotable td {
       padding: 8px;
   }
+
+/* Print media rules for proper page breaking */
+@media print {
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  .container {
+    width: 960px;
+    margin: 0;
+    padding: 0;
+  }
+
+  .innercontainer {
+    page-break-after: always;
+    page-break-inside: avoid;
+    margin: 0;
+  }
+
+  table {
+    page-break-inside: avoid;
+  }
+
+  table tbody tr {
+    page-break-inside: avoid;
+  }
+
+  .modal {
+    display: none;
+  }
+}
 

--- a/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.html
+++ b/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.html
@@ -13,8 +13,13 @@
 
 </div>
 <div *ngIf="dataLoaded">
+    <div *ngIf="showDebug" style="background:#fafafa;border:1px solid #ddd;padding:8px;margin-bottom:8px;">
+        <strong>Debug: paginatedSignInSheetData</strong>
+        <pre style="max-height:250px;overflow:auto;margin:4px 0">{{debugData | json}}</pre>
+    </div>
+
     <div class="container">
-        <div *ngFor="let signInSheet of signInSheetData" class="innercontainer">
+        <div *ngFor="let signInSheet of paginatedSignInSheetData" class="innercontainer">
             <img [src]="signInSheet.event.eventPictureUrl | imageDimension: '480x360' " alt="" class="headerimage">
             <table class="infotable">
                 <thead>
@@ -25,11 +30,14 @@
                     </tr>
                     <tr>
                         <td>Members: {{signInSheet.memberAttendanceCount}}&nbsp;&nbsp;&nbsp;Teams: {{signInSheet.teamAttendanceCount}}</td>
-                        <td>Member Pin: {{signInSheet.groupMemberPinCode}}</td>
+                        <td style="display:flex;justify-content:space-between;align-items:center;">
+                            <span>Member Pin: {{signInSheet.groupMemberPinCode}}</span>
+                            <span style="text-align:right">Page: {{signInSheet.pageNumber}}/{{signInSheet.totalPages}}</span>
+                        </td>
                     </tr>
                 </tbody>
             </table>
-            <table>
+                        <table>
                 <thead>
                     <tr>
                         <th class="col1">Name</th>
@@ -40,18 +48,25 @@
                 </thead>
                 <tbody>
 
-                    <tr *ngFor="let dataRow of signInSheet.memberAttendances">
-                        <td>{{dataRow.groupMemberName}}</td>
-                        <td><span *ngFor="let activityMemberAttendance of dataRow.attendanceActivities">[{{activityMemberAttendance.activityTitle}}]</span></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
-                    <tr *ngFor="let spareRow of spareRows">
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                        <td></td>
-                    </tr>
+                                        <ng-container *ngIf="signInSheet.memberAttendances && signInSheet.memberAttendances.length > 0; else noAttendees">
+                                            <tr *ngFor="let dataRow of signInSheet.memberAttendances">
+                                                <td>{{dataRow.groupMemberName}}</td>
+                                                <td><span *ngFor="let activityMemberAttendance of dataRow.attendanceActivities">[{{activityMemberAttendance.activityTitle}}]</span></td>
+                                                <td></td>
+                                                <td></td>
+                                            </tr>
+                                            <tr *ngFor="let spareRow of signInSheet.spareRows">
+                                                <td></td>
+                                                <td></td>
+                                                <td></td>
+                                                <td></td>
+                                            </tr>
+                                        </ng-container>
+                                        <ng-template #noAttendees>
+                                            <tr>
+                                                <td colspan="4" style="text-align:center; font-style:italic; color:#666;">No attendees on this page</td>
+                                            </tr>
+                                        </ng-template>
 
                 </tbody>
             </table>

--- a/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.html
+++ b/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.html
@@ -13,10 +13,6 @@
 
 </div>
 <div *ngIf="dataLoaded">
-    <div *ngIf="showDebug" style="background:#fafafa;border:1px solid #ddd;padding:8px;margin-bottom:8px;">
-        <strong>Debug: paginatedSignInSheetData</strong>
-        <pre style="max-height:250px;overflow:auto;margin:4px 0">{{debugData | json}}</pre>
-    </div>
 
     <div class="container">
         <div *ngFor="let signInSheet of paginatedSignInSheetData" class="innercontainer">
@@ -29,15 +25,17 @@
                         <td colspan="2">{{signInSheet.groupName}}</td>
                     </tr>
                     <tr>
-                        <td>Members: {{signInSheet.memberAttendanceCount}}&nbsp;&nbsp;&nbsp;Teams: {{signInSheet.teamAttendanceCount}}</td>
+                        <td>Members: {{signInSheet.memberAttendanceCount}}&nbsp;&nbsp;&nbsp;Teams:
+                            {{signInSheet.teamAttendanceCount}}</td>
                         <td style="display:flex;justify-content:space-between;align-items:center;">
                             <span>Member Pin: {{signInSheet.groupMemberPinCode}}</span>
-                            <span style="text-align:right">Page: {{signInSheet.pageNumber}}/{{signInSheet.totalPages}}</span>
+                            <span style="text-align:right">Page:
+                                {{signInSheet.pageNumber}}/{{signInSheet.totalPages}}</span>
                         </td>
                     </tr>
                 </tbody>
             </table>
-                        <table>
+            <table>
                 <thead>
                     <tr>
                         <th class="col1">Name</th>
@@ -47,26 +45,29 @@
                     </tr>
                 </thead>
                 <tbody>
-
-                                        <ng-container *ngIf="signInSheet.memberAttendances && signInSheet.memberAttendances.length > 0; else noAttendees">
-                                            <tr *ngFor="let dataRow of signInSheet.memberAttendances">
-                                                <td>{{dataRow.groupMemberName}}</td>
-                                                <td><span *ngFor="let activityMemberAttendance of dataRow.attendanceActivities">[{{activityMemberAttendance.activityTitle}}]</span></td>
-                                                <td></td>
-                                                <td></td>
-                                            </tr>
-                                            <tr *ngFor="let spareRow of signInSheet.spareRows">
-                                                <td></td>
-                                                <td></td>
-                                                <td></td>
-                                                <td></td>
-                                            </tr>
-                                        </ng-container>
-                                        <ng-template #noAttendees>
-                                            <tr>
-                                                <td colspan="4" style="text-align:center; font-style:italic; color:#666;">No attendees on this page</td>
-                                            </tr>
-                                        </ng-template>
+                    <ng-container
+                        *ngIf="signInSheet.memberAttendances && signInSheet.memberAttendances.length > 0; else noAttendees">
+                        <tr *ngFor="let dataRow of signInSheet.memberAttendances">
+                            <td>{{dataRow.groupMemberName}}</td>
+                            <td><span
+                                    *ngFor="let activityMemberAttendance of dataRow.attendanceActivities">[{{activityMemberAttendance.activityTitle}}]</span>
+                            </td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                        <tr *ngFor="let spareRow of signInSheet.spareRows">
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                            <td></td>
+                        </tr>
+                    </ng-container>
+                    <ng-template #noAttendees>
+                        <tr>
+                            <td colspan="4" style="text-align:center; font-style:italic; color:#666;">No attendees on
+                                this page</td>
+                        </tr>
+                    </ng-template>
 
                 </tbody>
             </table>

--- a/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.ts
+++ b/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.ts
@@ -18,8 +18,6 @@ export class SignInSheetsComponent implements OnInit, OnDestroy {
   public dataLoaded: boolean = false;
   public signInSheetData: Array<SignInSheetDto> = [];
   public paginatedSignInSheetData: Array<any> = [];
-  public debugData: any = null;
-  public showDebug: boolean = false;
   private readonly ROWS_PER_PAGE = 26; // Calculated based on A4 landscape height
 
   constructor(
@@ -50,8 +48,6 @@ export class SignInSheetsComponent implements OnInit, OnDestroy {
       this.dataLoaded = true;
       this.signInSheetData = data;
       this.paginatedSignInSheetData = this.paginateSignInSheetData(data);
-      this.debugData = this.paginatedSignInSheetData;
-      console.log('paginatedSignInSheetData (first 3):', this.paginatedSignInSheetData.slice(0,3));
     });
   }
 

--- a/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.ts
+++ b/src/client/src/app/modules/paperwork-generator/components/signinsheets/signinsheets.component.ts
@@ -17,6 +17,10 @@ export class SignInSheetsComponent implements OnInit, OnDestroy {
 
   public dataLoaded: boolean = false;
   public signInSheetData: Array<SignInSheetDto> = [];
+  public paginatedSignInSheetData: Array<any> = [];
+  public debugData: any = null;
+  public showDebug: boolean = false;
+  private readonly ROWS_PER_PAGE = 26; // Calculated based on A4 landscape height
 
   constructor(
     private _activatedRoute: ActivatedRoute,
@@ -45,6 +49,49 @@ export class SignInSheetsComponent implements OnInit, OnDestroy {
       subs.unsubscribe();
       this.dataLoaded = true;
       this.signInSheetData = data;
+      this.paginatedSignInSheetData = this.paginateSignInSheetData(data);
+      this.debugData = this.paginatedSignInSheetData;
+      console.log('paginatedSignInSheetData (first 3):', this.paginatedSignInSheetData.slice(0,3));
     });
+  }
+
+  private paginateSignInSheetData(signInSheets: Array<SignInSheetDto>): Array<any> {
+    const paginatedData: Array<any> = [];
+
+    signInSheets.forEach(sheet => {
+      const membersArray = sheet.memberAttendances || [];
+      const totalMembers = membersArray.length;
+      const totalPages = Math.max(1, Math.ceil(totalMembers / this.ROWS_PER_PAGE));
+
+      for (let page = 0; page < totalPages; page++) {
+        const startIdx = page * this.ROWS_PER_PAGE;
+        const endIdx = startIdx + this.ROWS_PER_PAGE;
+        const pageMembers = membersArray.slice(startIdx, endIdx);
+
+        // Calculate spare rows to fill the page
+        const spareRowsCount = Math.max(0, this.ROWS_PER_PAGE - pageMembers.length);
+        const spareRows = Array(spareRowsCount).fill(null);
+
+        // Provide safe fallbacks for properties that may not exist on the DTO
+        const groupName = sheet['groupName'] || (sheet.registration ? `Group ${sheet.registration.groupId}` : '');
+        const memberAttendanceCount = totalMembers;
+        const teamAttendanceCount = sheet['teamAttendanceCount'] || 0;
+        const groupMemberPinCode = sheet['groupMemberPinCode'] || '';
+
+        paginatedData.push({
+          event: sheet.event,
+          groupName: groupName,
+          memberAttendanceCount: memberAttendanceCount,
+          teamAttendanceCount: teamAttendanceCount,
+          groupMemberPinCode: groupMemberPinCode,
+          memberAttendances: pageMembers,
+          spareRows: spareRows,
+          pageNumber: page + 1,
+          totalPages: totalPages
+        });
+      }
+    });
+
+    return paginatedData;
   }
 }


### PR DESCRIPTION
## Description

Added Pagination to the sign-in sheets such that when the number of attending members overflows the single landscape page a new page is created for the same team with the overflow members on page 2,3 etc.

Fixes #31  

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Test A - Have have clones the production database and produced the sheets for 2026 locally with this change and where I was previously seeing the overflow I now se separate pages. 

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules